### PR TITLE
Added proxyChildren property to ReorderableGridView

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -103,9 +103,10 @@ class _DemoReorderableGridState extends State<DemoReorderableGrid> {
         child: ReorderableGridView(
           crossAxisSpacing: 10,
           mainAxisSpacing: 10,
-          crossAxisCount: 3,
+          crossAxisCount: 2,
           childAspectRatio: 0.6, // 0 < childAspectRatio <= 1.0
           children: this.data.map((e) => buildItem(e)).toList(),
+          proxyChildren: this.data.map((e) => buildItem2(e)).toList(),
           onReorder: (oldIndex, newIndex) {
             print("reorder: $oldIndex -> $newIndex");
             setState(() {
@@ -128,7 +129,22 @@ class _DemoReorderableGridState extends State<DemoReorderableGrid> {
   Widget buildItem(int index) {
     return Card(
       key: ValueKey(index),
-      child: Text(index.toString()),
+      child: Text(
+        index.toString(),
+        style: TextStyle(color: Colors.black),
+      ),
+    );
+  }
+
+  Widget buildItem2(int index) {
+    return Card(
+      key: ValueKey(index),
+      elevation: 3.0,
+      color: Colors.cyanAccent,
+      child: Text(
+        index.toString(),
+        style: TextStyle(color: Colors.red),
+      ),
     );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -103,7 +103,7 @@ class _DemoReorderableGridState extends State<DemoReorderableGrid> {
         child: ReorderableGridView(
           crossAxisSpacing: 10,
           mainAxisSpacing: 10,
-          crossAxisCount: 2,
+          crossAxisCount: 3,
           childAspectRatio: 0.6, // 0 < childAspectRatio <= 1.0
           children: this.data.map((e) => buildItem(e)).toList(),
           proxyChildren: this.data.map((e) => buildItem2(e)).toList(),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0-alpha"
+    version: "1.1.0-alpha.1"
   sky_engine:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
proxyChildren widgets would replace the dragging widget. So we can use it to show custom dragging widget with different properties like elevation, color, etc without affecting the look of non-dragging widgets.


https://user-images.githubusercontent.com/72334435/126956992-691c97cb-c0bb-4436-a6b7-6620f3f67e37.mp4

