### PR TITLE
Update reorderable_sliver_grid_view.dart

### DIFF
--- a/lib/src/reorderable_sliver_grid_view.dart
+++ b/lib/src/reorderable_sliver_grid_view.dart
@@ -89,6 +89,7 @@ class ReorderableSliverGridView extends StatelessWidget {
     return ReorderableWrapperWidget(
       onReorder: onReorder,
       dragWidgetBuilder: dragWidgetBuilderV2,
+      dragStartDelay: dragStartDelay,
       scrollSpeedController: scrollSpeedController,
       placeholderBuilder: placeholderBuilder,
       onDragStart: onDragStart,

--- a/lib/src/reorderable_sliver_grid_view.dart
+++ b/lib/src/reorderable_sliver_grid_view.dart
@@ -90,6 +90,7 @@ class ReorderableSliverGridView extends StatelessWidget {
       onReorder: onReorder,
       dragWidgetBuilder: dragWidgetBuilderV2,
       dragStartDelay: dragStartDelay,
+      dragEnabled: dragEnabled,
       scrollSpeedController: scrollSpeedController,
       placeholderBuilder: placeholderBuilder,
       onDragStart: onDragStart,


### PR DESCRIPTION
Fix SliverGrid param "dragStartDelay" and "dragEnabled" not use in ReorderableWrapperWidget.